### PR TITLE
fix(utils): add timeouts to all HTTP requests

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,7 +66,7 @@ export async function nodeInfo(remoteUrl: string): Promise<NodeInfo> {
     const inputUrl = remoteUrl.replace(/\/$/g, '').trim()
     const httpsUrl = inputUrl.startsWith("http") ? inputUrl : `https://${inputUrl}`
 
-    const response = await axios.get(httpsUrl, { httpsAgent })
+    const response = await axios.get(httpsUrl, { httpsAgent, timeout: 10000 })
     return (response.data as NodeResponse).result as NodeInfo
 }
 
@@ -89,7 +89,7 @@ export async function privKeyFromMnemonic({ mnemonic, bip39Password, hdPath }: {
  * @returns GeoIPLocation with all geo-ip information like city country etc
  */
 export async function fetchLocation(address?: string): Promise<GeoIPLocation> {
-    const response = await axios.get("http://ip-api.com/json/" + (address || ''))
+    const response = await axios.get("http://ip-api.com/json/" + (address || ''), { timeout: 10000 })
     return response.data as GeoIPLocation
 }
 
@@ -238,6 +238,7 @@ export async function handshake(
             'Content-Type': 'application/json',
         },
         httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+        timeout: 60000,
     });
     // .result, supponsing success: True and error doesn't exist
     return response.data.result as NodeHandshakeResult;


### PR DESCRIPTION
## Summary
- Add `timeout: 10000` (10s) to `nodeInfo()` and `fetchLocation()` axios calls
- Add `timeout: 60000` (60s) to `handshake()` axios call
- Previously, if a node accepted the TCP connection but stopped responding, these calls would hang indefinitely with no error surfaced to the caller

10s is appropriate for simple GET requests (node info, geo-IP lookup). 60s gives the handshake endpoint more headroom since it may involve on-chain verification before responding.

Fixes #37