### PR TITLE
fix(v2ray): use dynamic port for SOCKS5 inbound instead of hardcoded 1080

### DIFF
--- a/src/vpn/v2ray/index.ts
+++ b/src/vpn/v2ray/index.ts
@@ -104,10 +104,12 @@ export class V2Ray {
     config: V2RayConf;
     uuid: string;
     child: null | ChildProcessWithoutNullStreams;
+    socksPort: number;
 
     constructor() {
         this.child = null;
         this.uuid = randomUUID();
+        this.socksPort = 0;
         // https://github.com/sentinel-official/sentinel-go-sdk/blob/development/v2ray/client.json.tmpl
         this.config = {
             api: { services: ["StatsService"], tag: "api" },
@@ -170,7 +172,8 @@ export class V2Ray {
         nodeAddrs: string[],
     ): Promise<void> {
         const address = nodeAddrs[0];
-        const [apiPort] = await findFreePorts(1);
+        const [apiPort, socksPort] = await findFreePorts(2);
+        this.socksPort = socksPort;
 
         // API inbound
         this.config.inbounds.push({
@@ -184,7 +187,7 @@ export class V2Ray {
         // SOCKS proxy inbound
         this.config.inbounds.push({
             listen: "127.0.0.1",
-            port: 1080,
+            port: socksPort,
             protocol: "socks",
             settings: { ip: "127.0.0.1", udp: true },
             sniffing: { destOverride: ["http", "tls"], enabled: true },


### PR DESCRIPTION
## Summary
- Replace hardcoded SOCKS5 inbound port `1080` with a dynamically allocated free port via `findFreePorts(2)` (already a dependency)
- Expose the assigned SOCKS port as a public `socksPort` property on the `V2Ray` class so callers know where to connect
- Prevents V2Ray startup failure ("address already in use") when port 1080 is occupied by other proxy software, which wastes tokens since the session payment has already been made

## Test plan
- [ ] Verify `parseConfig()` assigns two distinct free ports (API + SOCKS)
- [ ] Verify `socksPort` property is accessible after `parseConfig()` completes
- [ ] Verify V2Ray starts successfully when port 1080 is already in use by another process

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)