### PR TITLE
fix(provider): add missing 't' in MsgUpdateParamsTypeUrl

### DIFF
--- a/src/modules/provider/consts.ts
+++ b/src/modules/provider/consts.ts
@@ -3,4 +3,4 @@ export const protobufPackage = "sentinel.provider.v3";
 export const MsgRegisterProviderTypeUrl = `/${protobufPackage}.MsgRegisterProviderRequest`
 export const MsgUpdateProviderDetailsTypeUrl = `/${protobufPackage}.MsgUpdateProviderDetailsRequest`
 export const MsgUpdateProviderStatusTypeUrl = `/${protobufPackage}.MsgUpdateProviderStatusRequest`
-export const MsgUpdateParamsTypeUrl = `/${protobufPackage}.MsgUpdateParamsReques`
+export const MsgUpdateParamsTypeUrl = `/${protobufPackage}.MsgUpdateParamsRequest`


### PR DESCRIPTION
## Summary

- Fixed a typo in `src/modules/provider/consts.ts` where `MsgUpdateParamsTypeUrl` was set to `/sentinel.provider.v3.MsgUpdateParamsReques` (missing trailing `t`)
- The correct value is `/sentinel.provider.v3.MsgUpdateParamsRequest`
- This typo causes a registry mismatch when attempting provider parameter update transactions, as the type URL does not match the protobuf message name

Fixes #31