### PR TITLE
fix(wireguard): set MTU 1280 as default to prevent TLS handshake failures

### DIFF
--- a/src/vpn/wireguard/index.ts
+++ b/src/vpn/wireguard/index.ts
@@ -98,7 +98,8 @@ export class Wireguard {
     public async parseConfig(
         handshakeData: WireGuardHandshakeData,
         nodeAddrs: string[],
-        dns: string[] = ["10.8.0.1", "1.0.0.1", "1.1.1.1"]
+        dns: string[] = ["10.8.0.1", "1.0.0.1", "1.1.1.1"],
+        mtu: number = 1280
     ): Promise<void> {
         const [listenPort] = await findFreePorts(1);
 
@@ -108,6 +109,7 @@ export class Wireguard {
             addresses: handshakeData.addrs,
             listenPort,
             dns,
+            mtu,
         };
 
         // Use the first available metadata to build the peer endpoint
@@ -181,6 +183,7 @@ export class Wireguard {
         config += "Address = " + this.interface.addresses.join(",") + "\n";
         config += "PrivateKey = " + this.interface.privateKey + "\n";
         config += "DNS = " + this.interface.dns.join(",") + "\n";
+        if (this.interface.mtu) config += "MTU = " + this.interface.mtu + "\n";
 
         config += "\n[Peer]\n";
         config += "PublicKey = " + this.peer.publicKey + "\n";


### PR DESCRIPTION
## Summary

- Set WireGuard MTU to 1280 (the minimum IPv6 MTU) as the default in `parseConfig()`, preventing TLS handshake failures caused by packet fragmentation at the OS default of 1420
- Made MTU configurable via an optional `mtu` parameter on `parseConfig()` (defaults to 1280)
- Added MTU output to `buildConfigString()` so QR codes and displayed configs include it (was already present in `writeConfig()`)

## Details

Without an explicit MTU, the OS defaults to 1420 which causes packet fragmentation issues with TLS handshakes on certain Sentinel nodes. MTU 1280 is safe for all network configurations and matches the Sentinel Go SDK reference implementation.

The `Interface` type already had an `mtu?: number` field and `writeConfig()` already emitted it when set — this PR ensures it is actually populated by default and also emitted by `buildConfigString()`.

Fixes #41

## Test plan

- [ ] Verify `parseConfig()` sets `interface.mtu` to 1280 by default
- [ ] Verify `parseConfig()` accepts a custom MTU value
- [ ] Verify `writeConfig()` includes `MTU = 1280` in the generated config file
- [ ] Verify `buildConfigString()` includes `MTU = 1280` in the output string
- [ ] Verify `printQRCode()` generates a QR code containing the MTU setting
- [ ] Test WireGuard connection to a Sentinel node with the default MTU 1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)