### PR TITLE
fix(handshake): prevent session ID precision loss for large uint64 values

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,7 +106,7 @@ export async function fetchLocation(address?: string): Promise<GeoIPLocation> {
  */
 function uint64ToBigEndian(id: Long): Uint8Array {
     const buf = new Uint8Array(8);
-    let n = BigInt(id.toNumber());
+    let n = BigInt(id.toString());
     for (let i = 7; i >= 0; i--) {
         buf[i] = Number(n & BigInt(0xff));
         n >>= BigInt(8);
@@ -224,7 +224,7 @@ export async function handshake(
 
     const body = {
         data: Buffer.from(JSON.stringify(data)).toString('base64'), // []byte Go → base64
-        id: Number(sessionId),
+        id: sessionId.toString(),
         pub_key: `secp256k1:${pubKeyBase64}`,
         signature: signature,
     };


### PR DESCRIPTION
## Summary

- Fix precision loss when converting session IDs (uint64) to JavaScript `Number` in `handshake()` — `Number()` silently truncates values above `2^53` (`Number.MAX_SAFE_INTEGER`)
- Fix the same class of bug in `uint64ToBigEndian()` where `Long.toNumber()` also loses precision before the `BigInt` conversion
- Both call sites now use `toString()` to preserve full uint64 precision

## Details

Session IDs are uint64 values that can exceed `Number.MAX_SAFE_INTEGER` (2^53 - 1). Two places in `src/utils.ts` converted these IDs through JavaScript's `Number` type, which silently rounds large integers:

1. **`handshake()` POST body** — `id: Number(sessionId)` sent a rounded session ID to the node, causing handshake failures or connecting to the wrong session.
2. **`uint64ToBigEndian()`** — `BigInt(id.toNumber())` produced incorrect big-endian bytes for signature computation, causing signature verification to fail on the node side.

Both are fixed by going through `toString()` instead, which preserves the full precision of the original `Long` value.

Fixes #32

## Test plan

- [ ] Verify handshake succeeds with session IDs below 2^53 (no regression)
- [ ] Verify handshake succeeds with session IDs above 2^53 (the bug fix)
- [ ] Verify signature bytes match expected big-endian encoding for large IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)