### PR TITLE
fix(example): use 'uid' field name for V2Ray handshake data

### DIFF
--- a/examples/node/main.ts
+++ b/examples/node/main.ts
@@ -113,7 +113,7 @@ const main = async () => {
             const v2ray = new V2Ray()
             const result = await handshake(
                 sessionId,
-                { uuid: v2ray.getKey() },
+                { uid: v2ray.getKey() },
                 privkey,
                 p2pNode.node.remoteAddrs[0],
             );


### PR DESCRIPTION
## Summary

- Fix V2Ray handshake field name in `examples/node/main.ts`: `uuid` -> `uid`
- The Go SDK (`sentinel-go-sdk`) expects `uid` as the field name in the V2Ray peer request data, not `uuid`
- The `handshake` JSDoc in `utils.ts` (line 176) already documents this correctly as `uid`

Fixes #33

## Test plan

- [ ] Verify the V2Ray handshake example works correctly with a V2Ray node
- [ ] Confirm the field name matches the Go SDK's `client.json.tmpl` peer data format