### PR TITLE
fix(wireguard): propagate wg-quick errors instead of swallowing them

### DIFF
--- a/src/vpn/wireguard/index.ts
+++ b/src/vpn/wireguard/index.ts
@@ -220,31 +220,28 @@ export class Wireguard {
      *
      * @param configFile - Optional path to an existing `.conf` file.
      *   If omitted, writes the current config to a temp file first.
+     * @returns Promise that resolves on success or rejects with error details.
      */
-    public connect(configFile?: string) {
+    public connect(configFile?: string): Promise<void> {
         if (configFile == undefined) {
-            // const randomFile = "wg_" + randomBytes(8).toString('hex') + ".conf"
-            // pkexec wg-quick up /tmp/sentinel-js-sdkR2Resv/wg_76294e9ab0aac67f.conf
-            // wg-quick: The config file must be a valid interface name, followed by .conf
-
-            /* Recommended INTERFACE names include `wg0' or `wgvpn0' or even `wgmgmtlan0'.  However,  the
-            number  at  the  end  is  in  fact  optional,  and  really  any  free-form  string  [a-zA-
-            Z0-9_=+.-]{1,15} will work. So even interface names corresponding to geographic  locations
-            would suffice, such as `cincinnati', `nyc', or `paris', if that's somehow desirable */
-
             const randomFile = "wgsent0.conf"
             const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'sentinel-js-sdk'))
             configFile = path.join(tempDirectory, randomFile)
-            // Hope the config are in "memory"
             this.writeConfig(configFile)
         }
-        const child = spawn("wg-quick", ["up", configFile])
-        child.stdout.setEncoding('utf8');
-        child.stdout.on('data', function (data) { console.log('stdout: ' + data.trim()); });
+        return new Promise((resolve, reject) => {
+            const child = spawn("wg-quick", ["up", configFile!]);
+            let stderr = '';
 
-        child.stderr.setEncoding('utf8');
-        child.stderr.on('data', function (data) { console.log('stderr: ' + data.trim()); });
-        child.on('close', (code) => console.log(`wg-quick up exited with code ${code}.`));
+            child.stdout.setEncoding('utf8');
+            child.stderr.setEncoding('utf8');
+            child.stderr.on('data', (data) => { stderr += data; });
+            child.on('error', (err) => reject(new Error(`Failed to start wg-quick: ${err.message}`)));
+            child.on('close', (code) => {
+                if (code === 0) resolve();
+                else reject(new Error(`wg-quick up failed (exit code ${code}): ${stderr.trim()}`));
+            });
+        });
     }
 
     /**
@@ -252,15 +249,22 @@ export class Wireguard {
      * Requires sudo/root privileges.
      *
      * @param configFile - Path to the `.conf` file used when connecting.
+     * @returns Promise that resolves on success or rejects with error details.
      */
-    public disconnect(configFile: string) {
-        const child = spawn("wg-quick", ["down", configFile])
-        child.stdout.setEncoding('utf8');
-        child.stdout.on('data', function (data) { console.log('stdout: ' + data.trim()); });
+    public disconnect(configFile: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const child = spawn("wg-quick", ["down", configFile]);
+            let stderr = '';
 
-        child.stderr.setEncoding('utf8');
-        child.stderr.on('data', function (data) { console.log('stderr: ' + data.trim()); });
-        child.on('close', (code) => console.log(`wg-quick down exited with code ${code}.`));
+            child.stdout.setEncoding('utf8');
+            child.stderr.setEncoding('utf8');
+            child.stderr.on('data', (data) => { stderr += data; });
+            child.on('error', (err) => reject(new Error(`Failed to start wg-quick: ${err.message}`)));
+            child.on('close', (code) => {
+                if (code === 0) resolve();
+                else reject(new Error(`wg-quick down failed (exit code ${code}): ${stderr.trim()}`));
+            });
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
- `connect()` and `disconnect()` now return `Promise<void>` instead of `void`, allowing callers to `await` them and catch failures.
- Collects stderr output and includes it in rejection error messages along with the exit code.
- Listens for the `error` event on the spawned process (e.g. when `wg-quick` is not found) and rejects with a descriptive message.
- Removes stale comments and console-only logging that silently swallowed failures.

## Motivation
Previously, if `wg-quick up` or `wg-quick down` failed (wrong permissions, missing binary, bad config), the error was logged to console and discarded. Callers had no way to detect or react to tunnel failures. This is especially problematic for automated/daemon use cases where silent failures lead to traffic leaking outside the tunnel.

Fixes #39

## Test plan
- [ ] Call `connect()` without root/sudo privileges and verify the returned Promise rejects with exit code and stderr
- [ ] Call `connect()` with a valid config as root and verify the Promise resolves
- [ ] Call `disconnect()` on a non-existent interface and verify rejection with stderr details
- [ ] Verify `await connect()` / `await disconnect()` work correctly in async callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)