### PR TITLE
fix(provider): add missing 't' in MsgUpdateParamsTypeUrl

### DIFF
--- a/src/modules/provider/consts.ts
+++ b/src/modules/provider/consts.ts
@@ -3,4 +3,4 @@ export const protobufPackage = "sentinel.provider.v3";
 export const MsgRegisterProviderTypeUrl = `/${protobufPackage}.MsgRegisterProviderRequest`
 export const MsgUpdateProviderDetailsTypeUrl = `/${protobufPackage}.MsgUpdateProviderDetailsRequest`
 export const MsgUpdateProviderStatusTypeUrl = `/${protobufPackage}.MsgUpdateProviderStatusRequest`
-export const MsgUpdateParamsTypeUrl = `/${protobufPackage}.MsgUpdateParamsReques`
+export const MsgUpdateParamsTypeUrl = `/${protobufPackage}.MsgUpdateParamsRequest`


### PR DESCRIPTION
Fixes #31.

Real bug, not cosmetic: the provider module's `MsgUpdateParamsTypeUrl` was missing the trailing 't' — chain registry lookup would reject `MsgUpdateParamsReques` as unknown, breaking any tx using this type URL.

```diff
- export const MsgUpdateParamsTypeUrl = `/${protobufPackage}.MsgUpdateParamsReques`
+ export const MsgUpdateParamsTypeUrl = `/${protobufPackage}.MsgUpdateParamsRequest`
```

Single-character fix. No type/API surface changes (the exported name is unchanged — only the string value), so consumers that were working around this by hand-constructing the correct URL will start hitting the real constant naturally.