### PR TITLE
fix(wireguard): set MTU 1280 as default to prevent TLS handshake failures

### DIFF
--- a/src/vpn/wireguard/index.ts
+++ b/src/vpn/wireguard/index.ts
@@ -98,7 +98,8 @@ export class Wireguard {
     public async parseConfig(
         handshakeData: WireGuardHandshakeData,
         nodeAddrs: string[],
-        dns: string[] = ["10.8.0.1", "1.0.0.1", "1.1.1.1"]
+        dns: string[] = ["10.8.0.1", "1.0.0.1", "1.1.1.1"],
+        mtu: number = 1280
     ): Promise<void> {
         const [listenPort] = await findFreePorts(1);
 
@@ -108,6 +109,7 @@ export class Wireguard {
             addresses: handshakeData.addrs,
             listenPort,
             dns,
+            mtu,
         };
 
         // Use the first available metadata to build the peer endpoint
@@ -181,6 +183,7 @@ export class Wireguard {
         config += "Address = " + this.interface.addresses.join(",") + "\n";
         config += "PrivateKey = " + this.interface.privateKey + "\n";
         config += "DNS = " + this.interface.dns.join(",") + "\n";
+        if (this.interface.mtu) config += "MTU = " + this.interface.mtu + "\n";
 
         config += "\n[Peer]\n";
         config += "PublicKey = " + this.peer.publicKey + "\n";


### PR DESCRIPTION
Rebased onto current `development` (replaces #76, auto-closed after retarget from `main`→`development` due to base divergence). Single commit, same fix, cleanly rebased onto `development` HEAD `732bf85`.