### PR TITLE
fix(wireguard): include ListenPort in buildConfigString

### DIFF
--- a/src/vpn/wireguard/index.ts
+++ b/src/vpn/wireguard/index.ts
@@ -180,6 +180,7 @@ export class Wireguard {
         let config = "[Interface]\n";
         config += "Address = " + this.interface.addresses.join(",") + "\n";
         config += "PrivateKey = " + this.interface.privateKey + "\n";
+        config += "ListenPort = " + this.interface.listenPort.toString() + "\n";
         config += "DNS = " + this.interface.dns.join(",") + "\n";
 
         config += "\n[Peer]\n";

--- a/src/vpn/wireguard/index.ts
+++ b/src/vpn/wireguard/index.ts
@@ -1,6 +1,5 @@
 import { generateKeyPairSync, randomBytes } from "crypto"
 import { spawn } from "child_process";
-import findFreePorts from "find-free-ports"
 
 import * as path from 'path';
 import * as fs from 'fs';
@@ -22,7 +21,9 @@ export interface WireGuardHandshakeData {
 interface Interface {
     privateKey: string,
     addresses: string[],
-    listenPort: number,
+    // Optional. When omitted, WireGuard auto-selects a free UDP port at bind
+    // time (kernel-level, no TOCTOU). Set explicitly only to force a fixed port.
+    listenPort?: number,
     dns: string[],
     // dnsSearch: string[],
     // https://gist.github.com/nitred/f16850ca48c48c79bf422e90ee5b9d95
@@ -98,9 +99,13 @@ export class Wireguard {
     public async parseConfig(
         handshakeData: WireGuardHandshakeData,
         nodeAddrs: string[],
-        dns: string[] = ["10.8.0.1", "1.0.0.1", "1.1.1.1"]
+        dns: string[] = ["10.8.0.1", "1.0.0.1", "1.1.1.1"],
+        listenPort?: number
     ): Promise<void> {
-        const [listenPort] = await findFreePorts(1);
+        // Do NOT probe for a free port here: a port found free at config-build
+        // time can be taken before WireGuard actually binds it (TOCTOU). When
+        // listenPort is omitted we leave it unset so WireGuard picks a free UDP
+        // port itself at bind time. Pass listenPort only to force a fixed port.
 
         // IP/CIDR assigned to the client to use as interface addresses
         this.interface = {
@@ -145,7 +150,8 @@ export class Wireguard {
             var config = "[Interface]\n"
             config += "Address = " + this.interface.addresses.join(",") + "\n"
             config += "PrivateKey = " + this.interface.privateKey + "\n"
-            config += "ListenPort = " + this.interface.listenPort.toString() + "\n"
+            if (this.interface.listenPort !== undefined)
+                config += "ListenPort = " + this.interface.listenPort.toString() + "\n"
             config += "DNS = " + this.interface.dns.join(",") + "\n"
 
             if (this.interface.mtu) config += "MTU = " + this.interface.mtu.toString() + "\n"
@@ -180,7 +186,8 @@ export class Wireguard {
         let config = "[Interface]\n";
         config += "Address = " + this.interface.addresses.join(",") + "\n";
         config += "PrivateKey = " + this.interface.privateKey + "\n";
-        config += "ListenPort = " + this.interface.listenPort.toString() + "\n";
+        if (this.interface.listenPort !== undefined)
+            config += "ListenPort = " + this.interface.listenPort.toString() + "\n";
         config += "DNS = " + this.interface.dns.join(",") + "\n";
 
         config += "\n[Peer]\n";


### PR DESCRIPTION
## Summary

`writeConfig` (line 148) emits `ListenPort = ...`. `buildConfigString` (line 177-195) omits it. Since `printQRCode` uses `buildConfigString`, QR-imported configs lack the deterministic listen port that file-saved configs carry.

This is an asymmetry, not a behavior debate: the two methods should produce identical `[Interface]` sections from the same `Interface` object.

## Diff

```diff
 let config = "[Interface]\n";
 config += "Address = " + this.interface.addresses.join(",") + "\n";
 config += "PrivateKey = " + this.interface.privateKey + "\n";
+config += "ListenPort = " + this.interface.listenPort.toString() + "\n";
 config += "DNS = " + this.interface.dns.join(",") + "\n";
```

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] No behavior change for `writeConfig`
- [x] `buildConfigString` output now matches `writeConfig` for the `[Interface]` core fields