### PR TITLE
fix(utils): harden parseAttributes against non-JSON attribute values

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,10 +18,11 @@ import { NodeResponse, NodeInfo, GeoIPLocation, NodeHandshakeResult } from "./ty
  * @returns Object with key: value, where key is in camelCase and value is escaped
  */
 export function parseAttributes(attributes: readonly Attribute[] | Attribute[]): any {
-    return Object.fromEntries(attributes.map((x: Attribute) => [
-        x.key.replace(/_([a-z])/g, (_, p1) => p1.toUpperCase()),
-        JSON.parse(x.value)
-    ]))
+    return Object.fromEntries(attributes.map((x: Attribute) => {
+        const key = x.key.replace(/_([a-z])/g, (_, p1) => p1.toUpperCase());
+        try { return [key, JSON.parse(x.value)]; }
+        catch { return [key, x.value]; }
+    }))
 }
 
 /**


### PR DESCRIPTION
## Summary

`JSON.parse(x.value)` in \`parseAttributes\` throws on raw-string attribute values. Cosmos SDK >=0.50 emits event attribute values as plain strings (no JSON quoting), so on any chain past 0.47, calling \`parseAttributes\` on a real event with one non-JSON attribute crashes the entire parse for that tx.

Sentinel chain hasn't bitten this yet because of where it sits on the SDK fork tree, but every consumer using this helper against another Cosmos chain hits it on day 1, and it will bite once Sentinel rebases.

## Diff

\`\`\`diff
 export function parseAttributes(attributes: readonly Attribute[] | Attribute[]): any {
-    return Object.fromEntries(attributes.map((x: Attribute) => [
-        x.key.replace(/_([a-z])/g, (_, p1) => p1.toUpperCase()),
-        JSON.parse(x.value)
-    ]))
+    return Object.fromEntries(attributes.map((x: Attribute) => {
+        const key = x.key.replace(/_([a-z])/g, (_, p1) => p1.toUpperCase());
+        try { return [key, JSON.parse(x.value)]; }
+        catch { return [key, x.value]; }
+    }))
 }
\`\`\`

## Why this is safe

Already-JSON values still parse identically. The only behavior change is raw strings round-trip as raw strings instead of throwing. No reasonable consumer was relying on the throw — a thrown \`parseAttributes\` is always a bug at the call site.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] JSON-quoted values still decode (unchanged path)
- [x] Raw-string values now return as the raw string instead of throwing