### PR TITLE
feat(vpn): prefer IPv4 in nodeAddrs selection for outbound VPN dial

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,6 +50,21 @@ export function uintArrayTob64(value: number[]): string {
     return btoa(String.fromCharCode.apply(null, value))
 }
 
+/**
+ * Pick the best node address for an outbound VPN connection. Prefers IPv4
+ * when present; falls back to the first entry (typically IPv6) otherwise.
+ *
+ * Sentinel chain does not guarantee ordering of `result.addrs` returned by
+ * the node handshake, so consumers on v4-only networks need this preference
+ * to avoid silent dial failures on dual-stack nodes.
+ *
+ * @param addrs Address strings from `result.addrs` (no port suffix expected)
+ * @returns The preferred address, or `addrs[0]` if no IPv4 is found
+ */
+export function preferIPv4(addrs: string[]): string {
+    return addrs.find(a => /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(a)) ?? addrs[0];
+}
+
 
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import Long from "long";
 import secp256k1 from "secp256k1";
 import axios from 'axios';
 import https from 'https'
+import { isIP } from "net"  // 0: not an IP (domain), 4: IPv4, 6: IPv6
 
 import { NodeResponse, NodeInfo, GeoIPLocation, NodeHandshakeResult } from "./types";
 
@@ -62,7 +63,10 @@ export function uintArrayTob64(value: number[]): string {
  * @returns The preferred address, or `addrs[0]` if no IPv4 is found
  */
 export function preferIPv4(addrs: string[]): string {
-    return addrs.find(a => /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(a)) ?? addrs[0];
+    // Use Node's net.isIP (returns 4 for IPv4) rather than a hand-rolled regex,
+    // matching how src/vpn/v2ray validates addresses. isIP correctly rejects
+    // out-of-range octets (e.g. "999.1.1.1") that a loose \d{1,3} regex accepts.
+    return addrs.find(a => isIP(a) === 4) ?? addrs[0];
 }
 
 

--- a/src/vpn/v2ray/index.ts
+++ b/src/vpn/v2ray/index.ts
@@ -9,6 +9,8 @@ import * as os from 'os';
 import V2RayConf from "./v2ray-conf";
 import { V2RayStreamSettings } from "./v2ray-transport";
 
+import { preferIPv4 } from "../../utils";
+
 /**
  * Proxy protocol types. Maps to ProxyProtocol iota in sentinel-go-sdk/v2ray/server.go
  * 0 = Unspecified, 1 = VLess, 2 = VMess
@@ -169,7 +171,7 @@ export class V2Ray {
         handshakeData: V2RayHandshakeData,
         nodeAddrs: string[],
     ): Promise<void> {
-        const address = nodeAddrs[0];
+        const address = preferIPv4(nodeAddrs);
         const [apiPort] = await findFreePorts(1);
 
         // API inbound

--- a/src/vpn/wireguard/index.ts
+++ b/src/vpn/wireguard/index.ts
@@ -8,6 +8,8 @@ import * as os from 'os';
 
 import qrcode from 'qrcode';
 
+import { preferIPv4 } from "../../utils";
+
 interface WireGuardMetadata {
     port: number;
     public_key: string;
@@ -114,7 +116,7 @@ export class Wireguard {
         const meta = handshakeData.metadata[0];
 
         // Endpoint = public IP of the node (from result.addrs) + port (from metadata)
-        const host = nodeAddrs[0];
+        const host = preferIPv4(nodeAddrs);
         const endpoint = `${host}:${meta.port}`;
 
         this.peer = {


### PR DESCRIPTION
## Summary

Both \`Wireguard.parseConfig\` and \`V2Ray.parseConfig\` pick \`nodeAddrs[0]\` for the outbound endpoint:

- \`src/vpn/wireguard/index.ts:117\` — \`const host = nodeAddrs[0];\`
- \`src/vpn/v2ray/index.ts:172\` — \`const address = nodeAddrs[0];\`

Sentinel chain does not guarantee ordering of \`result.addrs\` returned by the node handshake. On dual-stack nodes that return IPv6 first, consumers on v4-only networks (typical home / mobile) silently fail to dial — \`UDP send: network unreachable\` for WireGuard, \`connection refused\` / no route for V2Ray.

## Fix

Add a small \`preferIPv4\` helper in \`src/utils.ts\` and use it from both VPN classes. Falls back to \`addrs[0]\` when no IPv4 entry is present, so v6-only consumers see no behavior change.

## Diff (helper)

\`\`\`ts
export function preferIPv4(addrs: string[]): string {
    return addrs.find(a => /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(a)) ?? addrs[0];
}
\`\`\`

## Diff (call sites)

\`\`\`diff
-const host = nodeAddrs[0];
+const host = preferIPv4(nodeAddrs);
\`\`\`

\`\`\`diff
-const address = nodeAddrs[0];
+const address = preferIPv4(nodeAddrs);
\`\`\`

## Note

If you'd rather inline the helper at the call sites instead of exporting it from utils, happy to refactor. Centralized helper keeps the rationale comment in one place.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] v4-first arrays unchanged (helper returns \`addrs[0]\`)
- [x] v6-first arrays now return the v4 entry
- [x] v6-only arrays unchanged (helper returns \`addrs[0]\` via nullish fallback)