### PR TITLE
docs(node): warn QueryNodes truncates without next_key + add isActiveStatus helper

### DIFF
--- a/src/modules/node/query.ts
+++ b/src/modules/node/query.ts
@@ -25,7 +25,23 @@ import { Node } from "../../protobuf/sentinel/node/v3/node";
 
 export interface NodeExtension {
     readonly node: {
+        /**
+         * Query nodes by status.
+         *
+         * NOTE: Sentinel chain v3 does not return `pagination.next_key` for
+         * this query even when results are truncated. To enumerate all nodes
+         * reliably, do not loop on `next_key` — use a sufficiently large
+         * `limit` in a single call, or paginate by `offset`.
+         *
+         * Reproducible against mainnet: a status=ACTIVE query that has more
+         * than `limit` matching nodes still returns `next_key=null`.
+         */
         nodes: (status: Status, pagination?: PageRequest) => Promise<QueryNodesResponse>,
+        /**
+         * Query nodes joined to a plan by status. Same `next_key` caveat
+         * as `nodes()` — chain v3 does not emit it on truncation. Use
+         * `offset`-based pagination or a sufficiently large `limit`.
+         */
         nodesForPlan: (id: Long, status: Status, pagination?: PageRequest) => Promise<QueryNodesForPlanResponse>,
         node: (address: string) => Promise<Node | undefined>,
         params: () => Promise<Params | undefined>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import axios from 'axios';
 import https from 'https'
 
 import { NodeResponse, NodeInfo, GeoIPLocation, NodeHandshakeResult } from "./types";
+import { Status } from "./protobuf/sentinel/types/v1/status";
 
 /**
  * Convert an array of stargate/Attribute in to javascript object
@@ -48,6 +49,21 @@ export function searchEvent(eventUrl: string, events: readonly Event[] | Event[]
  */
 export function uintArrayTob64(value: number[]): string {
     return btoa(String.fromCharCode.apply(null, value))
+}
+
+/**
+ * True if the given status (in any of its on-chain shapes) represents
+ * `STATUS_ACTIVE`. Sentinel chain v3 emits status as the string
+ * `"STATUS_ACTIVE"` in LCD JSON, the numeric `1` in RPC protobuf, and
+ * the typed `Status.STATUS_ACTIVE` enum when decoded by ts-proto. This
+ * helper accepts all three so consumers don't need to remember which
+ * shape they're looking at.
+ *
+ * @param s status value from a chain query (string, number, or Status enum)
+ * @returns true if active
+ */
+export function isActiveStatus(s: string | number | Status): boolean {
+    return s === Status.STATUS_ACTIVE || s === "STATUS_ACTIVE" || s === 1;
 }
 
 


### PR DESCRIPTION
## Summary

Two chain v3 footguns that bite consumers on day 1. This PR addresses both with the smallest possible surface area: JSDoc warnings + one tiny exported helper.

## 1. `QueryNodes` / `QueryNodesForPlan` return `next_key=null` on truncation

Sentinel chain v3 does not emit `pagination.next_key` for these queries even when results are truncated. Consumers writing the obvious \`while (next_key)\` loop silently drop nodes.

**Reproducible against mainnet:**

\`\`\`bash
curl 'https://lcd.sentinel.co/sentinel/node/v3/plans/36/nodes?pagination.limit=500' \
  | jq '{count: (.nodes | length), next: .pagination.next_key}'
# => { "count": 500, "next": null }

curl 'https://lcd.sentinel.co/sentinel/node/v3/plans/36/nodes?pagination.offset=500&pagination.limit=500' \
  | jq '.nodes | length'
# => 303     (so plan 36 actually has 803 nodes; the first call hid 303 of them)
\`\`\`

The fix is pure JSDoc — direct callers to use a large \`limit\` or \`offset\`-based pagination instead of trusting \`next_key\`.

## 2. Status comes in three shapes — add an \`isActiveStatus\` helper

Subscription / session / node status is emitted as:

- \`"STATUS_ACTIVE"\` in LCD JSON
- numeric \`1\` over RPC
- typed \`Status.STATUS_ACTIVE\` enum after ts-proto decode

Consumers who pick one shape and forget the others get silent zero results when their data source changes (e.g., switching from LCD to RPC). 10-line helper in \`utils.ts\`:

\`\`\`ts
export function isActiveStatus(s: string | number | Status): boolean {
    return s === Status.STATUS_ACTIVE || s === "STATUS_ACTIVE" || s === 1;
}
\`\`\`

Strictly opt-in. No existing call site changes. \`statusFromJSON\` from the generated proto already handles the same conversion, but it lives in \`protobuf/\` and consumers don't typically reach there — this exposes the equivalent check from the public utils surface.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] No runtime behavior change (JSDoc + new export only)
- [x] \`isActiveStatus\` returns true for all three shapes; false for inactive variants