### PR TITLE
fix(handshake): check node response envelope instead of blindly returning result

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,8 +181,11 @@ function encodePubKey(compressedPubKey: Uint8Array): string {
  * @returns A `NodeHandshakeResult` containing:
  *   - `result.addrs` — list of node endpoints to connect to (e.g. `["1.2.3.4:51820"]`)
  *   - `result.data`  — VPN configuration returned by the node (WireGuard config or v2ray inbound)
- * @throws Will throw if the HTTP request fails, the session is not active on-chain,
- *   or the signature verification fails on the node side (HTTP 401)
+ * @throws Will throw if the HTTP request fails, OR if the node returns an
+ *   unsuccessful envelope (`success: false` / an `error` payload, which can
+ *   arrive as HTTP 200) — e.g. the session is not active on-chain or signature
+ *   verification failed. The thrown message includes the node's error code and
+ *   text when present. Also throws if a successful response has no `result`.
  *
  * @example
  * // WireGuard
@@ -239,6 +242,23 @@ export async function handshake(
         },
         httpsAgent: new https.Agent({ rejectUnauthorized: false }),
     });
-    // .result, supponsing success: True and error doesn't exist
-    return response.data.result as NodeHandshakeResult;
+    // The node wraps every response as { success, result?, error? }. A failed
+    // handshake (bad signature, session not active, node-side error) can still
+    // arrive as HTTP 200 with success:false and an error payload, so we must
+    // check the envelope rather than blindly returning .result.
+    const payload = response.data as NodeResponse;
+
+    if (!payload.success || payload.error) {
+        const code = payload.error?.code;
+        const message = payload.error?.message ?? "unknown node error";
+        throw new Error(
+            `Handshake rejected by node${code !== undefined ? ` (code ${code})` : ""}: ${message}`
+        );
+    }
+
+    if (!payload.result) {
+        throw new Error("Handshake response missing result payload");
+    }
+
+    return payload.result as NodeHandshakeResult;
 }


### PR DESCRIPTION
## What

`handshake()` in `src/utils.ts` now validates the node's response envelope before returning, instead of blindly returning `response.data.result`.

## Why

Every node response is wrapped as `NodeResponse { success: boolean, result?, error?: { code, message } }` (see `src/types.ts`). A failed handshake — bad signature, session not active on-chain, or any node-side error — can come back as **HTTP 200 with `success: false`** and an `error` payload. axios does not throw on that, so the old code:

```ts
// .result, supponsing success: True and error doesn't exist
return response.data.result as NodeHandshakeResult;
```

returned `undefined` (the comment even admits it assumes the happy path). The failure then surfaced much later as an opaque crash during tunnel setup (`result.addrs` of undefined, etc.) instead of a clear, actionable error at the handshake boundary.

## Change

```ts
const payload = response.data as NodeResponse;

if (!payload.success || payload.error) {
    const code = payload.error?.code;
    const message = payload.error?.message ?? "unknown node error";
    throw new Error(`Handshake rejected by node${code !== undefined ? ` (code ${code})` : ""}: ${message}`);
}
if (!payload.result) {
    throw new Error("Handshake response missing result payload");
}
return payload.result as NodeHandshakeResult;
```

JSDoc `@throws` updated to document the new behavior. No type changes needed — `NodeResponse` / `NodeResponseError` already model this exactly.

## Scope / relationship to #75

This is the clean, correctly-scoped implementation of the original error-checking request (#34). The earlier #75 was *titled* "add response error checking" but never touched the return path — it only flipped `uuid`→`uid` in an example (a change already merged as wrong via #90 and rejected once in #78). #75 has been closed; this PR does what #34 actually asked for, against `src/utils.ts`, and nothing else.

## Verification

`tsc --noEmit` passes clean on this branch.

## Follow-up (not in this PR)

`nodeInfo()` (same file) has the identical pattern — `return (response.data as NodeResponse).result as NodeInfo` with no `success`/`error` check. Left out to keep this PR focused on the handshake path; happy to send a sibling PR applying the same guard there.
