### PR TITLE
fix(utils): check node response envelope in nodeInfo instead of returning result blindly

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,6 +57,10 @@ export function uintArrayTob64(value: number[]): string {
  *
  * @param remoteUrl node endpoint
  * @returns NodeInfo information
+ * @throws Error if the node responds with success:false / an error payload, or
+ *   returns no result. The node wraps every response as { success, result?, error? };
+ *   a failed query can still arrive as HTTP 200 with success:false, so we must check
+ *   the envelope rather than blindly returning .result (which would be undefined).
  */
 export async function nodeInfo(remoteUrl: string, timeout: number = 10000): Promise<NodeInfo> {
     const httpsAgent = new https.Agent({
@@ -67,7 +71,21 @@ export async function nodeInfo(remoteUrl: string, timeout: number = 10000): Prom
     const httpsUrl = inputUrl.startsWith("http") ? inputUrl : `https://${inputUrl}`
 
     const response = await axios.get(httpsUrl, { httpsAgent, timeout: timeout })
-    return (response.data as NodeResponse).result as NodeInfo
+    const payload = response.data as NodeResponse;
+
+    if (!payload.success || payload.error) {
+        const code = payload.error?.code;
+        const message = payload.error?.message ?? "unknown node error";
+        throw new Error(
+            `Node info request rejected by node${code !== undefined ? ` (code ${code})` : ""}: ${message}`
+        );
+    }
+
+    if (!payload.result) {
+        throw new Error("Node info response missing result payload");
+    }
+
+    return payload.result as NodeInfo
 }
 
 /**


### PR DESCRIPTION
## What

`nodeInfo()` in `src/utils.ts` returned `(response.data as NodeResponse).result as NodeInfo` without inspecting the response envelope. Every node response is wrapped as `{ success: boolean, result?, error? }`. On an HTTP-200 response with `success: false` (node-side error, node not ready, bad request), `result` is `undefined`, so `nodeInfo()` returned `undefined` and the failure surfaced much later — as an unrelated crash in node selection / connection setup, with no indication the node itself rejected the query.

This is the **sibling of #109** (`handshake()` had the identical unchecked-`.result` bug). This PR applies the same envelope check to `nodeInfo()`:

- If `!success` or an `error` payload is present → throw a descriptive `Error` carrying the node's `code` + `message`.
- If `result` is missing → throw `"Node info response missing result payload"`.
- Otherwise return `payload.result as NodeInfo`.

JSDoc `@throws` added.

## Why (consumer context)

Surfaced while building the **x402 AI-agent VPN flow** (agent pays USDC on Base → gets a Sentinel dVPN subscription → connects). When a node answered with `success:false`, the pre-connect `nodeInfo()` probe returned `undefined` instead of failing, so the error only appeared deep in tunnel setup as a confusing downstream crash rather than a clear "node rejected the request (code N): message" at the probe site. Same root cause as the handshake bug in #109.

## Change

- `src/utils.ts` — `nodeInfo()` now checks the `NodeResponse` envelope before returning `.result`. +19 / −1.

## Verification

- `npx tsc --noEmit` → exit 0 (compiles against real SDK types; not grep-level).
- Pattern mirrors the already-reviewed #109 handshake fix exactly, for consistency.

Base: `development`.
